### PR TITLE
devx: remove rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.92.0"
-components = ["clippy", "rustfmt"]


### PR DESCRIPTION
no longer necessary now we have mise
